### PR TITLE
fix: avoid leaking link task storage errors

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,6 +1,7 @@
 ## GOTCHA
 
 - Symptom: LLM/agent behavior becomes fragile when code repairs model output or upstream warnings by matching text fragments. Cause: behavior policy is encoded in ad hoc string operations instead of instructions or structured fields. Fix: prefer structured tool outputs, explicit policy fields, tool descriptions, and response contracts; reserve string handling for input normalization and display formatting.
+- Symptom: Link messages can reply with raw `[Errno 17] File exists: '.telegramagent'`. Cause: background task/session persistence failures can happen after a successful agent run and leak `str(exc)` to Telegram. Fix: keep replies independent from durable history writes and use generic user-facing task failure text while logging server-side details.
 
 ## TASTE
 

--- a/src/telegramagent/actions.py
+++ b/src/telegramagent/actions.py
@@ -422,8 +422,9 @@ class ProactiveActionTool:
         text = _html_to_text(raw_text) if "text/html" in content_type else raw_text
         text = _collapse_whitespace(html.unescape(text))[: self.settings.max_extracted_chars]
         title = _html_title(raw_text) or parsed.netloc
-        if _is_x_status_url(url) and _looks_like_x_blocker_page(text, title=title):
-            raise ActionError("X 回傳的是 JavaScript/browser unsupported 頁面，不是貼文內容。")
+        blocker_error = _blocker_error_for_url(url, text, title=title)
+        if blocker_error is not None:
+            raise ActionError(blocker_error)
         if not text:
             raise ActionError("這個頁面沒有讀到可摘要的文字內容。")
         return ActionContent(title=title, source_url=url, body=text, content_type="web_page")
@@ -459,12 +460,19 @@ class _TextExtractor(HTMLParser):
 _URL_RE = re.compile(r"https?://[^\s<>()]+", flags=re.IGNORECASE)
 _YOUTUBE_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com", "music.youtube.com", "youtu.be", "www.youtu.be"}
 _X_HOSTS = {"x.com", "www.x.com", "twitter.com", "www.twitter.com"}
+_REDDIT_HOSTS = {"reddit.com", "www.reddit.com", "old.reddit.com", "redd.it", "www.redd.it"}
 _X_BLOCKER_PHRASES = (
     "javascript is not available",
     "javascript is disabled in this browser",
     "enable javascript or switch to a supported browser",
     "switch to a supported browser to continue using x.com",
     "continue using x.com",
+)
+_REDDIT_BLOCKER_PHRASES = (
+    "reddit - please wait for verification",
+    "please wait for verification",
+    "verify you are a human",
+    "verify you're a human",
 )
 _SENSITIVE_ERROR_RE = re.compile(r"(?i)\b(token|api[_-]?key|authorization|cookie|set-cookie|password|secret)=([^\s;]+)")
 _BEARER_ERROR_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")
@@ -533,6 +541,10 @@ def _source_type_for_url(url: str) -> Literal["x_post", "webpage", "youtube", "u
     return "unknown"
 
 
+def _is_reddit_url(url: str) -> bool:
+    return (urlparse(url).hostname or "").casefold() in _REDDIT_HOSTS
+
+
 def _is_x_status_url(url: str) -> bool:
     parsed = urlparse(url)
     host = (parsed.hostname or "").casefold()
@@ -555,6 +567,24 @@ def _looks_like_x_blocker_page(
 ) -> bool:
     combined = " ".join(part for part in (title, description, text) if part).casefold()
     return bool(combined) and any(phrase in combined for phrase in _X_BLOCKER_PHRASES)
+
+
+def _looks_like_reddit_blocker_page(
+    text: str | None,
+    *,
+    title: str | None = None,
+    description: str | None = None,
+) -> bool:
+    combined = " ".join(part for part in (title, description, text) if part).casefold()
+    return bool(combined) and any(phrase in combined for phrase in _REDDIT_BLOCKER_PHRASES)
+
+
+def _blocker_error_for_url(url: str, text: str | None, *, title: str | None = None) -> str | None:
+    if _is_x_status_url(url) and _looks_like_x_blocker_page(text, title=title):
+        return "X 回傳的是 JavaScript/browser unsupported 頁面，不是貼文內容。"
+    if _is_reddit_url(url) and _looks_like_reddit_blocker_page(text, title=title):
+        return "Reddit 回傳的是驗證/反機器人頁面，不是貼文內容。"
+    return None
 
 
 def _latest_url_from_history(history: Sequence[tuple[str, str]]) -> str | None:
@@ -807,6 +837,10 @@ def _url_context_from_response(
 
     if source_type == "x_post" and _looks_like_x_blocker_page(text, title=title, description=description):
         raise ActionError("X 回傳的是 JavaScript/browser unsupported 頁面，不是貼文內容。")
+    if (_is_reddit_url(url) or _is_reddit_url(final_url)) and _looks_like_reddit_blocker_page(
+        text, title=title, description=description
+    ):
+        raise ActionError("Reddit 回傳的是驗證/反機器人頁面，不是貼文內容。")
 
     if source_type == "x_post" and author is None:
         x_parts = _x_status_parts(final_url) or _x_status_parts(url)

--- a/src/telegramagent/kabigon_tool.py
+++ b/src/telegramagent/kabigon_tool.py
@@ -35,7 +35,10 @@ async def kabigon_load_url(url: str) -> str:
     than the built-in URL fetcher, including YouTube, articles, PDFs, social posts,
     and audio/video pages. Localhost and private network URLs are blocked.
     """
-    return await load_url_with_kabigon(url)
+    try:
+        return await load_url_with_kabigon(url)
+    except KabigonLoadError as exc:
+        return f"Error: {exc}"
 
 
 async def _load_with_kabigon(url: str) -> str:

--- a/src/telegramagent/telegram.py
+++ b/src/telegramagent/telegram.py
@@ -561,7 +561,11 @@ class TelegramBot:
                 priority="next",
                 status_message_id=status_message_id,
             )
-            reply = task.output if task.status == "completed" else task.error or "任務沒有完成。"
+            if task.status == "completed":
+                reply = task.output
+            else:
+                logger.warning("Telegram background task {} failed with status={}", task.id, task.status)
+                reply = _task_failure_reply(task.status)
         else:
             reply = await action(object())
 
@@ -680,18 +684,41 @@ class TelegramBot:
         )
 
     def _history(self, chat_id: int) -> list[tuple[str, str]]:
+        memory_history = self.histories.get(chat_id)
         if self.session_log is not None:
-            return self.session_log.history(chat_id, limit=20)
+            try:
+                durable_history = self.session_log.history(chat_id, limit=20)
+            except Exception as exc:  # noqa: BLE001 - broken durable history must not block replies
+                logger.warning(
+                    "Session log history failed for chat_id={} with {}; using in-memory history",
+                    chat_id,
+                    type(exc).__name__,
+                )
+            else:
+                if memory_history:
+                    return [*durable_history, *memory_history][-20:]
+                return durable_history
         return self.histories.setdefault(chat_id, [])
 
     def _record_turn(self, chat_id: int, *, user_text: str, assistant_text: str, synthetic: bool = False) -> None:
         if self.session_log is not None:
-            self.session_log.append_turn(
-                chat_id, user_text=user_text, assistant_text=assistant_text, synthetic=synthetic
-            )
-            return
+            try:
+                self.session_log.append_turn(
+                    chat_id, user_text=user_text, assistant_text=assistant_text, synthetic=synthetic
+                )
+            except Exception as exc:  # noqa: BLE001 - keep the user reply even if durable history fails
+                logger.warning(
+                    "Session log append failed for chat_id={} with {}; falling back to in-memory history",
+                    chat_id,
+                    type(exc).__name__,
+                )
+            else:
+                return
+        self._append_in_memory_history(chat_id, ("user", user_text), ("assistant", assistant_text))
+
+    def _append_in_memory_history(self, chat_id: int, *turns: tuple[str, str]) -> None:
         history = self.histories.setdefault(chat_id, [])
-        history.extend([("user", user_text), ("assistant", assistant_text)])
+        history.extend(turns)
         del history[:-20]
 
     def _record_passive_group_context(
@@ -712,23 +739,32 @@ class TelegramBot:
             return
         message_id = message.get("message_id")
         if self.session_log is not None:
-            self.session_log.append(
-                chat_id,
-                "user",
-                text=passive_text,
-                role="user",
-                message_id=message_id,
-                metadata={"passive_group_context": True},
-            )
-            return
-        history = self.histories.setdefault(chat_id, [])
-        history.append(("user", passive_text))
-        del history[:-20]
+            try:
+                self.session_log.append(
+                    chat_id,
+                    "user",
+                    text=passive_text,
+                    role="user",
+                    message_id=message_id,
+                    metadata={"passive_group_context": True},
+                )
+            except Exception as exc:  # noqa: BLE001 - passive context should not break message handling
+                logger.warning(
+                    "Session log passive append failed for chat_id={} with {}; falling back to in-memory history",
+                    chat_id,
+                    type(exc).__name__,
+                )
+            else:
+                return
+        self._append_in_memory_history(chat_id, ("user", passive_text))
 
     def _clear_history(self, chat_id: int) -> None:
         self.histories.pop(chat_id, None)
         if self.session_log is not None:
-            self.session_log.clear_chat(chat_id)
+            try:
+                self.session_log.clear_chat(chat_id)
+            except Exception as exc:  # noqa: BLE001 - reset should still clear in-memory fallback history
+                logger.warning("Session log clear failed for chat_id={} with {}", chat_id, type(exc).__name__)
 
     async def _handle_builtin_command(
         self,
@@ -1441,6 +1477,12 @@ def _log_background_task_error(task: asyncio.Task[None]) -> None:
         task.result()
     except asyncio.CancelledError, httpx.HTTPError, TelegramApiError:
         logger.exception("Background Telegram task failed")
+
+
+def _task_failure_reply(status: str) -> str:
+    if status == "cancelled":
+        return "任務已取消。"
+    return "任務執行時遇到內部錯誤，沒有完成；請稍後再試。"
 
 
 def _is_management_command(text: str) -> bool:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -307,6 +307,44 @@ async def test_x_url_uses_kabigon_fallback_when_builtin_fetch_returns_browser_bl
 
 
 @pytest.mark.asyncio
+async def test_reddit_url_uses_kabigon_fallback_when_builtin_fetch_returns_verification_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = "https://www.reddit.com/r/SonyAlpha/comments/1f9xt2k/regrets_upgrading_to_a7cii/"
+
+    async def allow_host(host: str) -> None:
+        assert host == "www.reddit.com"
+
+    monkeypatch.setattr("telegramagent.actions._assert_public_host", allow_host)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == url
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/html; charset=utf-8"},
+            text=(
+                "<html><title>Reddit - Please wait for verification</title>"
+                "<body>Please wait for verification</body></html>"
+            ),
+        )
+
+    external_loader = FakeExternalLoader()
+    tool = ProactiveActionTool(
+        http_client_factory=lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        capabilities=CapabilityRegistry([Capability("external_loader.kabigon", True, "test fallback")]),
+        external_loader=external_loader,
+    )
+    agent = FakeAgent()
+
+    reply = await tool.handle(url, chat_id=123, agent=agent, history=[])
+
+    assert reply == "整理完成"
+    assert external_loader.calls == [url]
+    assert "外部 loader 內容" in agent.prompts[0]
+    assert "Please wait for verification" not in agent.prompts[0]
+
+
+@pytest.mark.asyncio
 async def test_generic_url_blocks_localhost() -> None:
     tool = ProactiveActionTool()
     agent = FakeAgent()

--- a/tests/test_kabigon_tool.py
+++ b/tests/test_kabigon_tool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from telegramagent.kabigon_tool import KabigonLoadError
+from telegramagent.kabigon_tool import kabigon_load_url
 from telegramagent.kabigon_tool import load_url_with_kabigon
 
 
@@ -27,3 +28,10 @@ async def test_load_url_with_kabigon_calls_api_and_truncates(monkeypatch) -> Non
 async def test_load_url_with_kabigon_rejects_non_http_url() -> None:
     with pytest.raises(KabigonLoadError, match="http or https"):
         await load_url_with_kabigon("file:///etc/passwd")
+
+
+@pytest.mark.asyncio
+async def test_kabigon_tool_returns_safe_error_for_agent() -> None:
+    result = await kabigon_load_url("file:///etc/passwd")
+
+    assert result == "Error: kabigon tool only accepts http or https URLs"

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -594,6 +594,85 @@ async def test_handle_update_routes_long_action_through_background_task_queue() 
 
 
 @pytest.mark.asyncio
+async def test_background_link_reply_survives_session_log_append_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    telegram = FakeTelegram()
+    proactive = FakeProactiveTool(["背景整理完成"])
+    session_log = SessionLog(tmp_path / "sessions")
+
+    def fail_append_turn(chat_id: int, *, user_text: str, assistant_text: str, synthetic: bool = False) -> None:
+        raise FileExistsError(17, "File exists", ".telegramagent")
+
+    monkeypatch.setattr(session_log, "append_turn", fail_append_turn)
+    bot = TelegramBot(
+        telegram=telegram,
+        agent=FakeAgent(),
+        proactive_tool=proactive,
+        session_log=session_log,
+        task_queue=TaskQueue(),
+    )
+
+    await bot.handle_update(
+        {
+            "update_id": 1,
+            "message": {
+                "message_id": 10,
+                "chat": {"id": 123, "type": "private"},
+                "from": {"id": 456},
+                "text": "https://example.com",
+            },
+        }
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert telegram.edited == [(123, 100, "背景整理完成")]
+    assert bot.task_queue is not None
+    assert [task.status for task in bot.task_queue.list_records(chat_id=123)] == ["completed"]
+    assert bot.histories[123] == [("user", "https://example.com"), ("assistant", "背景整理完成")]
+
+
+@pytest.mark.asyncio
+async def test_background_task_failure_uses_generic_user_reply() -> None:
+    class ExplodingProactiveTool:
+        async def handle(
+            self,
+            text: str,
+            *,
+            chat_id: int,
+            agent: object,
+            history: Sequence[tuple[str, str]],
+        ) -> str | None:
+            raise FileExistsError(17, "File exists", ".telegramagent")
+
+    telegram = FakeTelegram()
+    bot = TelegramBot(
+        telegram=telegram,
+        agent=FakeAgent(),
+        proactive_tool=ExplodingProactiveTool(),
+        task_queue=TaskQueue(),
+    )
+
+    await bot.handle_update(
+        {
+            "update_id": 1,
+            "message": {
+                "message_id": 10,
+                "chat": {"id": 123, "type": "private"},
+                "from": {"id": 456},
+                "text": "https://example.com",
+            },
+        }
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert telegram.edited == [(123, 100, "任務執行時遇到內部錯誤，沒有完成；請稍後再試。")]
+    assert ".telegramagent" not in telegram.edited[0][2]
+
+
+@pytest.mark.asyncio
 async def test_proactive_tool_falls_back_to_agent_when_no_action_matches() -> None:
     proactive = FakeProactiveTool([None])
     bot = TelegramBot(telegram=FakeTelegram(), agent=FakeAgent(), proactive_tool=proactive)


### PR DESCRIPTION
## Summary
- keep Telegram replies working when durable session logging fails after link processing
- hide raw background task exceptions from user-facing messages
- detect Reddit verification pages and route them to kabigon fallback
- return safe error text from the kabigon Pydantic AI tool

## Verification
- uv run ruff format --check
- uv run ruff check .
- uv run ty check .
- uv run pytest -q tests