### PR TITLE
Disable group reply-to-bot trigger by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ BOT_WHITELIST=
 # Maximum consecutive replies to other bots in bot-to-bot reply chains.
 # Use 0 to never reply to other bots.
 BOT_MAX_CONSECUTIVE_REPLIES_TO_BOTS=1
+# In groups, replying to a bot message does not address the bot unless explicitly enabled.
+BOT_GROUP_REPLY_TO_BOT_ENABLED=false
 # In groups, keep unaddressed messages as passive context without replying or calling the LLM.
 BOT_GROUP_PASSIVE_CONTEXT_ENABLED=true
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ runtime tools such as kabigon, Yahoo Finance MCP, and container-local file tools
 
 ## ✨ Highlights
 
-- **Telegram-native behavior**: private chat replies, group mention handling, reply-to-bot handling, and bot-loop guards.
+- **Telegram-native behavior**: private chat replies, group mention handling, optional reply-to-bot handling, and bot-loop guards.
 - **Reply context**: when mentioned in a group reply, the bot includes the replied message sender, type, date, text/caption,
   and URL context in the LLM prompt.
 - **URL enrichment**: HTTP(S), YouTube, X/Twitter, and general webpages are fetched or loaded through kabigon when possible.
@@ -93,7 +93,8 @@ All runtime settings are environment variables. Start from `.env.example`; the m
 | --- | --- | --- |
 | `BOT_TOKEN` | empty | Telegram Bot API token from BotFather. |
 | `BOT_WHITELIST` | empty | Comma-separated chat IDs or user IDs allowed to use the bot. Empty allows everyone. |
-| `BOT_MAX_CONSECUTIVE_REPLIES_TO_BOTS` | `1` | Safety limit for bot-to-bot reply chains. Use `0` to never reply to bots. |
+| `BOT_MAX_CONSECUTIVE_REPLIES_TO_BOTS` | `1` | Safety limit for enabled bot-to-bot reply chains. Use `0` to never reply to bots. |
+| `BOT_GROUP_REPLY_TO_BOT_ENABLED` | `false` | In groups, allow a direct reply to a bot message to address the bot without `@mention`. |
 | `BOT_GROUP_PASSIVE_CONTEXT_ENABLED` | `true` | Store unaddressed group messages as passive context without replying. |
 
 ### Model
@@ -157,7 +158,7 @@ In private chats, the bot replies to normal text, commands, images, and supporte
 To avoid interrupting group conversations, the bot replies only when:
 
 1. The message mentions the bot, for example `@your_bot 你怎麼看？`
-2. The message directly replies to a bot message
+2. `BOT_GROUP_REPLY_TO_BOT_ENABLED=true` and the message directly replies to a bot message
 
 When `BOT_GROUP_PASSIVE_CONTEXT_ENABLED=true`, unaddressed group messages are stored as passive context without calling
 the LLM. The next addressed message can then use recent group context.

--- a/src/telegramagent/cli.py
+++ b/src/telegramagent/cli.py
@@ -329,6 +329,7 @@ def main(verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable deb
         agent=agent,
         whitelist=settings.bot_whitelist,
         max_consecutive_replies_to_bots=settings.bot_max_consecutive_replies_to_bots,
+        group_reply_to_bot_enabled=settings.bot_group_reply_to_bot_enabled,
         group_passive_context_enabled=settings.bot_group_passive_context_enabled,
         topic_end_judge=topic_end_judge,
         skill_tool=SkillManagementTool(

--- a/src/telegramagent/settings.py
+++ b/src/telegramagent/settings.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     bot_token: str = Field(default="", alias="BOT_TOKEN")
     bot_whitelist: Annotated[set[int], NoDecode] = Field(default_factory=set, alias="BOT_WHITELIST")
     bot_max_consecutive_replies_to_bots: int = Field(default=1, ge=0, alias="BOT_MAX_CONSECUTIVE_REPLIES_TO_BOTS")
+    bot_group_reply_to_bot_enabled: bool = Field(default=False, alias="BOT_GROUP_REPLY_TO_BOT_ENABLED")
     bot_group_passive_context_enabled: bool = Field(default=True, alias="BOT_GROUP_PASSIVE_CONTEXT_ENABLED")
     bot_skills_dir: Path = Field(default=Path(".agents/skills"), alias="BOT_SKILLS_DIR")
     bot_enabled_skills: Annotated[set[str], NoDecode] = Field(default_factory=set, alias="BOT_ENABLED_SKILLS")

--- a/src/telegramagent/telegram.py
+++ b/src/telegramagent/telegram.py
@@ -384,6 +384,7 @@ class TelegramBot:
         bot_username: str | None = None,
         bot_user_id: int | None = None,
         max_consecutive_replies_to_bots: int = 1,
+        group_reply_to_bot_enabled: bool = False,
         group_passive_context_enabled: bool = True,
         topic_end_judge: TopicEndJudge | None = None,
         skill_tool: SkillTool | None = None,
@@ -402,6 +403,7 @@ class TelegramBot:
         self.bot_username = bot_username
         self.bot_user_id = bot_user_id
         self.max_consecutive_replies_to_bots = max_consecutive_replies_to_bots
+        self.group_reply_to_bot_enabled = group_reply_to_bot_enabled
         self.group_passive_context_enabled = group_passive_context_enabled
         self.topic_end_judge = topic_end_judge
         self.skill_tool = skill_tool
@@ -1003,7 +1005,7 @@ class TelegramBot:
     def _should_respond_to_message(self, *, chat: TelegramChat, message: TelegramMessage, text: str) -> bool:
         if chat["type"] not in {"group", "supergroup"}:
             return True
-        return self._mentions_bot(text) or self._is_reply_to_bot(message)
+        return self._mentions_bot(text) or (self.group_reply_to_bot_enabled and self._is_reply_to_bot(message))
 
     def _mentions_bot(self, text: str) -> bool:
         if not self.bot_username:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -23,12 +23,20 @@ def test_proactive_settings_parse_env(monkeypatch) -> None:
     assert settings.bot_proactive_allowed_schemes == {"https"}
 
 
-def test_group_passive_context_setting_parse_env(monkeypatch) -> None:
+def test_group_settings_parse_env(monkeypatch) -> None:
+    monkeypatch.setenv("BOT_GROUP_REPLY_TO_BOT_ENABLED", "true")
     monkeypatch.setenv("BOT_GROUP_PASSIVE_CONTEXT_ENABLED", "false")
 
     settings = Settings()
 
+    assert settings.bot_group_reply_to_bot_enabled is True
     assert settings.bot_group_passive_context_enabled is False
+
+
+def test_group_reply_to_bot_defaults_off() -> None:
+    settings = Settings.model_validate({})
+
+    assert settings.bot_group_reply_to_bot_enabled is False
 
 
 def test_event_settings_parse_env(monkeypatch) -> None:

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1032,9 +1032,37 @@ async def test_group_mention_reply_photo_caption_includes_caption_context() -> N
 
 
 @pytest.mark.asyncio
-async def test_group_reply_to_bot_addresses_bot() -> None:
+async def test_group_reply_to_bot_does_not_address_bot_by_default() -> None:
     telegram = FakeTelegram()
     bot = TelegramBot(telegram=telegram, agent=FakeAgent(), bot_username="fakebot", bot_user_id=42)
+
+    await bot.handle_update(
+        {
+            "update_id": 1,
+            "message": {
+                "message_id": 11,
+                "chat": {"id": -100, "type": "supergroup"},
+                "from": {"id": 456},
+                "reply_to_message": {"message_id": 10, "from": {"id": 42, "username": "fakebot"}},
+                "text": "繼續說",
+            },
+        }
+    )
+
+    assert telegram.sent == []
+    assert bot.histories[-100] == [("user", "[群組旁聽訊息 from user_id=456] 繼續說")]
+
+
+@pytest.mark.asyncio
+async def test_group_reply_to_bot_addresses_bot_when_enabled() -> None:
+    telegram = FakeTelegram()
+    bot = TelegramBot(
+        telegram=telegram,
+        agent=FakeAgent(),
+        bot_username="fakebot",
+        bot_user_id=42,
+        group_reply_to_bot_enabled=True,
+    )
 
     await bot.handle_update(
         {
@@ -1061,6 +1089,7 @@ async def test_topic_end_judge_can_stop_bot_reply_without_answering() -> None:
         agent=FakeAgent(),
         bot_username="fakebot",
         bot_user_id=42,
+        group_reply_to_bot_enabled=True,
         topic_end_judge=judge,
     )
 
@@ -1090,6 +1119,7 @@ async def test_topic_end_judge_can_continue_bot_reply() -> None:
         agent=FakeAgent(),
         bot_username="fakebot",
         bot_user_id=42,
+        group_reply_to_bot_enabled=True,
         topic_end_judge=judge,
     )
 
@@ -1113,7 +1143,13 @@ async def test_topic_end_judge_can_continue_bot_reply() -> None:
 @pytest.mark.asyncio
 async def test_bot_to_bot_loop_stops_after_one_reply_without_judge() -> None:
     telegram = FakeTelegram()
-    bot = TelegramBot(telegram=telegram, agent=FakeAgent(), bot_username="fakebot", bot_user_id=42)
+    bot = TelegramBot(
+        telegram=telegram,
+        agent=FakeAgent(),
+        bot_username="fakebot",
+        bot_user_id=42,
+        group_reply_to_bot_enabled=True,
+    )
 
     await bot.handle_update(
         {
@@ -1146,7 +1182,13 @@ async def test_bot_to_bot_loop_stops_after_one_reply_without_judge() -> None:
 @pytest.mark.asyncio
 async def test_human_message_resets_bot_to_bot_loop_guard() -> None:
     telegram = FakeTelegram()
-    bot = TelegramBot(telegram=telegram, agent=FakeAgent(), bot_username="fakebot", bot_user_id=42)
+    bot = TelegramBot(
+        telegram=telegram,
+        agent=FakeAgent(),
+        bot_username="fakebot",
+        bot_user_id=42,
+        group_reply_to_bot_enabled=True,
+    )
 
     bot.bot_reply_streaks[-100] = 1
     await bot.handle_update(
@@ -1184,6 +1226,7 @@ async def test_bot_to_bot_replies_can_be_fully_disabled() -> None:
         agent=FakeAgent(),
         bot_username="fakebot",
         bot_user_id=42,
+        group_reply_to_bot_enabled=True,
         max_consecutive_replies_to_bots=0,
     )
 


### PR DESCRIPTION
## Summary
- add BOT_GROUP_REPLY_TO_BOT_ENABLED with default false
- gate group reply-to-bot addressing behind that setting
- update docs, env example, and tests

## Verification
- uv run ruff format --check
- uv run ruff check .
- uv run ty check .
- uv run pytest -q tests