### PR TITLE
fix(telegram): only edit final agent response

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,8 +50,6 @@ BOT_AGENT_CONTEXT_TOKEN_BUDGET=100000
 BOT_AGENT_COMPACTION_TRIGGER_RATIO=0.8
 # Approximation used when the provider cannot count context tokens ahead of a request.
 BOT_AGENT_CHARS_PER_TOKEN=4
-# Minimum interval between Telegram streaming edits; use 0 to disable throttling.
-BOT_AGENT_PROGRESS_EDIT_INTERVAL_SECONDS=0.5
 BOT_TASKS_MAX_CONCURRENT_PER_CHAT=1
 
 # Image input/output.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ runtime tools such as kabigon, Yahoo Finance MCP, Firecrawl MCP, and container-l
   endpoint when enabled.
 - **Long replies**: replies over Telegram's practical limit are published to Telegraph and replaced with a link.
 - **Durable context**: `SOUL.md` and structured per-chat model transcripts survive restarts.
-- **Agent runtime**: per-chat execution, streamed Telegram edits, mid-run steering, `/cancel`, transient retries, and automatic context compaction.
+- **Agent runtime**: per-chat execution, a single final Telegram status edit, mid-run steering, `/cancel`, transient retries, and automatic context compaction.
 - **Agent Skills**: local `.agents/skills/*/SKILL.md` files are loaded as model instructions.
 - **Docker-ready**: Compose includes mounted runtime state, Playwright browser assets, and optional container tools.
 
@@ -29,7 +29,7 @@ Telegram updates
   -> telegramagent.agent_runtime (per-chat state, steering, retry, compaction)
   -> telegramagent.llm via Pydantic AI
   -> OpenAI-compatible API and tools
-  -> streamed Telegram edits and final response
+  -> one final Telegram status edit and response
 ```
 
 Important modules:
@@ -119,7 +119,6 @@ All runtime settings are environment variables. Start from `.env.example`; the m
 | `BOT_AGENT_CONTEXT_TOKEN_BUDGET` | `100000` | Approximate context budget that drives automatic compaction. |
 | `BOT_AGENT_COMPACTION_TRIGGER_RATIO` | `0.8` | Fraction of the context budget at which compaction starts. |
 | `BOT_AGENT_CHARS_PER_TOKEN` | `4` | Token-estimation fallback when the provider cannot count ahead. |
-| `BOT_AGENT_PROGRESS_EDIT_INTERVAL_SECONDS` | `0.5` | Minimum interval between Telegram streaming edits. |
 | `BOT_SKILLS_DIR` | `.agents/skills` | Directory for Agent Skills. |
 | `BOT_ENABLED_SKILLS` | empty | Comma-separated skill names. Empty loads every skill. |
 | `BOT_SKILL_ADMINS` | empty | Users/chats allowed to manage skills/context files. Empty reuses `BOT_WHITELIST`. |

--- a/docs/plans/archived/2026-08-07_pi-style-agent-runtime-plan.md
+++ b/docs/plans/archived/2026-08-07_pi-style-agent-runtime-plan.md
@@ -10,7 +10,7 @@ Confirmed product decisions:
 
 - Keep Pydantic AI as the model and tool-loop implementation.
 - A new message received while the same chat is running is steering input and must be injected at the earliest Pydantic AI checkpoint.
-- Telegram streaming edits one throttled status message until it becomes the final answer.
+- Telegram shows one processing status and edits it once when the final answer is ready.
 - `/cancel` cancels the active run for the current chat and clears queued steering input.
 - Replace the existing session format without backward compatibility; operators must clear old sessions before deployment.
 - Compact automatically near the configured context budget, preserving a compaction record.
@@ -22,7 +22,7 @@ Confirmed product decisions:
 - Add `agent_runtime.py` as the owner of per-chat `AgentSession` state, active run control, steering, cancellation, retry policy, event fan-out, and compaction checkpoints. Telegram depends on this runtime instead of coordinating LLM state itself.
 - Keep `llm.py` as the Pydantic AI adapter. It will expose a streamed run contract, translate Pydantic model/tool events into normalized runtime events, bind the active `AgentRun.enqueue()` steering seam, and return exact structured model messages plus artifacts.
 - Replace `session.py` with a v2 append-only JSONL store for structured Pydantic messages and compaction records. It will provide exact model history to the runtime and a text projection for proactive URL behavior.
-- Add a throttled Telegram progress renderer. The polling loop dispatches updates concurrently; the runtime serializes work per chat while allowing different chats to proceed independently.
+- Add a single-update Telegram status renderer. The polling loop dispatches updates concurrently; the runtime serializes work per chat while allowing different chats to proceed independently.
 - Use Pydantic AI's default parallel tool manager and per-tool `sequential` declaration. Runtime before/after hooks observe normalized tool lifecycle events without reimplementing tool execution.
 - Automatic compaction estimates history tokens conservatively, asks a tool-free compactor for a summary, replaces old context with a summary request, and records the replacement. A failed compaction leaves the original history intact and reports an event.
 
@@ -35,7 +35,7 @@ Confirmed product decisions:
 
 ## Risks
 
-- Telegram edit rate limits: throttle progress edits and ignore recoverable edit failures without cancelling the run.
+- Telegram edit failures must not cancel the run; fall back to sending the final response when no editable status message exists.
 - Pydantic AI event/API drift: isolate framework-specific types in `llm.py` and test the runtime through protocols/fakes.
 - Context estimation is approximate when providers cannot count ahead: expose the budget and character-to-token ratio as settings and retain actual request usage in session metadata.
 - Cancelling a non-idempotent tool cannot undo effects already completed; cancellation stops future work and propagates to in-flight async operations where supported.
@@ -46,7 +46,7 @@ Confirmed product decisions:
 - [x] Replace `src/telegramagent/session.py` with the structured v2 message/compaction store and update focused session tests; verified 34 focused session/Telegram tests plus Ruff and ty checks passed.
 - [x] Add normalized agent events and the Pydantic AI streamed backend adapter in `src/telegramagent/agent_runtime.py` and `src/telegramagent/llm.py`, including parallel tool lifecycle events and exact message capture; verified 16 focused LLM/session tests plus Ruff and ty checks passed.
 - [x] Add per-chat sessions, earliest-checkpoint steering, real cancellation, transient retry/backoff, automatic summary compaction, and runtime hooks; verified 24 focused runtime/LLM/session tests plus Ruff and ty checks passed.
-- [x] Integrate the runtime into Telegram and CLI: concurrent update dispatch, throttled edit-in-place progress, `/cancel`, same-chat serialization, cross-chat parallelism, and structured history projection; verified 45 focused Telegram/CLI/runtime tests plus Ruff and ty checks passed.
+- [x] Integrate the runtime into Telegram and CLI: concurrent update dispatch, one final status edit, `/cancel`, same-chat serialization, cross-chat parallelism, and structured history projection; verified focused Telegram/CLI/runtime tests plus repository quality gates.
 - [x] Add runtime settings to `Settings`, `.env.example`, and README, including the breaking session-format deployment note; verified 57 focused settings/CLI/runtime/Telegram tests plus Ruff and ty checks passed.
 - [x] Re-index changed source and audit the final dependency direction and diff; graph index completed with 1,221 nodes/5,586 edges, all quality gates passed, and 191 tests passed.
 - [x] Push `feat/pi-style-agent-runtime`, create pull request #9 against `main`, and verify https://github.com/narumiruna/telegram-agent/pull/9.
@@ -54,7 +54,7 @@ Confirmed product decisions:
 ## Completion Checklist
 
 - [x] Same-chat messages steer an active run and different chats run concurrently.
-- [x] Telegram uses one throttled editable progress message and finishes it with the final response.
+- [x] Telegram sends one processing status and edits it once with the final response.
 - [x] `/cancel` stops the active run and discards queued steering messages.
 - [x] Structured v2 sessions restore exact model history and persist compaction records; old files are explicitly unsupported.
 - [x] Transient failures retry no more than three times with exponential backoff; permanent and cancellation failures do not retry.

--- a/src/telegramagent/cli.py
+++ b/src/telegramagent/cli.py
@@ -395,7 +395,6 @@ def main(verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable deb
         session_log=session_log,
         task_queue=task_queue,
         image_input_enabled=settings.bot_image_input_enabled,
-        progress_edit_interval_seconds=settings.bot_agent_progress_edit_interval_seconds,
         image_max_bytes=settings.bot_image_max_bytes,
         image_generator=image_generator,
         tools=[

--- a/src/telegramagent/settings.py
+++ b/src/telegramagent/settings.py
@@ -48,9 +48,6 @@ class Settings(BaseSettings):
         default=0.8, gt=0, le=1, alias="BOT_AGENT_COMPACTION_TRIGGER_RATIO"
     )
     bot_agent_chars_per_token: float = Field(default=4.0, gt=0, alias="BOT_AGENT_CHARS_PER_TOKEN")
-    bot_agent_progress_edit_interval_seconds: float = Field(
-        default=0.5, ge=0, alias="BOT_AGENT_PROGRESS_EDIT_INTERVAL_SECONDS"
-    )
     bot_tasks_max_concurrent_per_chat: int = Field(default=1, ge=1, alias="BOT_TASKS_MAX_CONCURRENT_PER_CHAT")
     bot_image_input_enabled: bool = Field(default=True, alias="BOT_IMAGE_INPUT_ENABLED")
     bot_image_max_bytes: int = Field(default=8_000_000, ge=1, alias="BOT_IMAGE_MAX_BYTES")

--- a/src/telegramagent/telegram.py
+++ b/src/telegramagent/telegram.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import re
-import time
 from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import replace
@@ -65,31 +64,16 @@ class _TelegramAgentProgress:
         telegram: TelegramGateway,
         chat_id: int,
         reply_to_message_id: int | None,
-        edit_interval_seconds: float,
     ) -> None:
         self.telegram = telegram
         self.chat_id = chat_id
         self.reply_to_message_id = reply_to_message_id
-        self.edit_interval_seconds = edit_interval_seconds
         self.message_id: int | None = None
-        self.message_text = ""
         self.last_rendered = ""
-        self.last_edit_at = 0.0
 
     async def handle(self, event: AgentEvent) -> None:
         if event.type == "agent_start":
             await self._ensure_message()
-        elif event.type == "message_start":
-            self.message_text = ""
-        elif event.type == "message_delta":
-            self.message_text += event.text
-            await self._edit(self.message_text or "思考中…")
-        elif event.type == "tool_start":
-            await self._edit(f"{self.message_text}\n\n🔧 正在執行 {event.tool_name}…".strip(), force=True)
-        elif event.type == "retry_scheduled":
-            await self._edit("AI 服務暫時忙碌, 正在重試…", force=True)
-        elif event.type == "compaction_start":
-            await self._edit("正在整理較早的對話內容…", force=True)
         elif event.type == "agent_end":
             await self.finish(event.text)
         elif event.type == "cancelled":
@@ -97,7 +81,7 @@ class _TelegramAgentProgress:
 
     async def finish(self, text: str) -> None:
         if self.message_id is not None:
-            await self._edit(text, force=True)
+            await self._edit(text)
 
     async def _ensure_message(self) -> None:
         if self.message_id is not None:
@@ -111,12 +95,9 @@ class _TelegramAgentProgress:
         except _TELEGRAM_API_ERRORS as exc:
             logger.warning("Failed to send agent progress message with {}", type(exc).__name__)
 
-    async def _edit(self, text: str, *, force: bool = False) -> None:
+    async def _edit(self, text: str) -> None:
         await self._ensure_message()
         if self.message_id is None or not text or text == self.last_rendered:
-            return
-        now = time.monotonic()
-        if not force and now - self.last_edit_at < self.edit_interval_seconds:
             return
         try:
             await self.telegram.edit_message_text(self.chat_id, self.message_id, text)
@@ -124,7 +105,6 @@ class _TelegramAgentProgress:
             logger.warning("Failed to edit agent progress message with {}", type(exc).__name__)
             return
         self.last_rendered = text
-        self.last_edit_at = now
 
 
 _TELEGRAM_API_ERRORS = (httpx.HTTPError, TelegramApiError)
@@ -154,7 +134,6 @@ class TelegramBot:
         image_max_bytes: int = 8_000_000,
         image_generator: ImageGenerator | None = None,
         url_context_extractor: UrlContextLoader | None = None,
-        progress_edit_interval_seconds: float = 0.5,
     ) -> None:
         self.telegram = telegram
         self.agent = agent
@@ -174,7 +153,6 @@ class TelegramBot:
         self.image_max_bytes = image_max_bytes
         self.image_generator = image_generator
         self.url_context_extractor = url_context_extractor or extract_url_context
-        self.progress_edit_interval_seconds = progress_edit_interval_seconds
         self.bot_reply_streaks: dict[int, int] = {}
         self.histories: dict[int, list[tuple[str, str]]] = {}
         self._update_tasks: set[asyncio.Task[None]] = set()
@@ -276,7 +254,6 @@ class TelegramBot:
                 telegram=self.telegram,
                 chat_id=chat_id,
                 reply_to_message_id=message_id,
-                edit_interval_seconds=self.progress_edit_interval_seconds,
             )
             if self.agent_runtime is not None
             else None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -65,7 +65,6 @@ def test_agent_runtime_settings_parse_env(monkeypatch) -> None:
     monkeypatch.setenv("BOT_AGENT_CONTEXT_TOKEN_BUDGET", "64000")
     monkeypatch.setenv("BOT_AGENT_COMPACTION_TRIGGER_RATIO", "0.75")
     monkeypatch.setenv("BOT_AGENT_CHARS_PER_TOKEN", "3.5")
-    monkeypatch.setenv("BOT_AGENT_PROGRESS_EDIT_INTERVAL_SECONDS", "0.2")
 
     settings = Settings()
 
@@ -74,7 +73,6 @@ def test_agent_runtime_settings_parse_env(monkeypatch) -> None:
     assert settings.bot_agent_context_token_budget == 64000
     assert settings.bot_agent_compaction_trigger_ratio == 0.75
     assert settings.bot_agent_chars_per_token == 3.5
-    assert settings.bot_agent_progress_edit_interval_seconds == 0.2
 
 
 def test_image_settings_parse_env(monkeypatch) -> None:

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -65,7 +65,7 @@ async def test_start_help_id_and_reset_commands() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runtime_streams_by_editing_one_telegram_message() -> None:
+async def test_runtime_edits_processing_status_once_with_final_answer() -> None:
     class FakeRuntime:
         async def submit(self, chat_id, prompt, *, images=(), event_handler=None):
             del chat_id, prompt, images
@@ -89,7 +89,6 @@ async def test_runtime_streams_by_editing_one_telegram_message() -> None:
         telegram=telegram,
         agent=FakeAgent(),
         agent_runtime=FakeRuntime(),
-        progress_edit_interval_seconds=0,
     )
 
     await bot.handle_update(
@@ -105,12 +104,12 @@ async def test_runtime_streams_by_editing_one_telegram_message() -> None:
     )
 
     assert telegram.sent == [(123, "處理中…", 10)]
-    assert telegram.edited[-1] == (123, 100, "partial answer")
+    assert telegram.edited == [(123, 100, "partial answer")]
     assert bot.histories == {}
 
 
 @pytest.mark.asyncio
-async def test_ask_command_uses_runtime_progress_stream() -> None:
+async def test_ask_command_edits_processing_status_once() -> None:
     class FakeRuntime:
         async def submit(self, chat_id, prompt, *, images=(), event_handler=None):
             del chat_id, prompt, images


### PR DESCRIPTION
## Summary

- keep the initial `處理中…` status message
- stop editing Telegram messages for model deltas, tool calls, retries, and compaction events
- edit the status exactly once when the final answer or cancellation result is ready
- remove the now-unused progress edit interval setting

## Verification

- `uv run ruff format --check`
- `uv run ruff check .`
- `uv run ty check .`
- `uv run pytest -q tests` — 191 passed
