### PR TITLE
fix(ci): require PAT for version bump

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,11 +23,21 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+      - name: Verify PAT_TOKEN
+        env:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          if [[ -z "$PAT_TOKEN" ]]; then
+            echo "::error::PAT_TOKEN repository secret is required to bump versions and trigger release workflows."
+            exit 1
+          fi
       - name: Bump version
         id: bump
         uses: callowayproject/bump-my-version@1.5.0
         env:
           BUMPVERSION_TAG: "true"
+          GIT_AUTHOR_NAME: ${{ github.actor }}
+          GIT_COMMITTER_NAME: ${{ github.actor }}
         with:
           args: ${{ inputs.bump-type }}
           # Use a Personal Access Token (PAT) to ensure the publish workflow is triggered on tag push


### PR DESCRIPTION
## Summary
- keep `PAT_TOKEN` as the credential used to commit and push version tags
- fail early with a clear error when the repository secret is missing
- use the workflow actor as a stable Git author and committer name
- preserve tag-push triggers for the Publish and Release workflows

Follow-up to the reverted #11. The original failure occurred because `PAT_TOKEN` resolved to an empty value.

## Required repository configuration
Add a repository Actions secret named `PAT_TOKEN` with permission to write repository contents. The secret is currently not configured, so the workflow will intentionally stop at the validation step until it is added.

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10 .github/workflows/*.yml`
- `uv run ruff format --check`
- `uv run ruff check .`
- `uv run ty check .`
- `uv run pytest -q tests` (191 passed)
